### PR TITLE
Updated Makefile to fix build failures on Ubuntu

### DIFF
--- a/native/Makefile
+++ b/native/Makefile
@@ -14,10 +14,10 @@ dep:
 	${CC} -c ${CFLAGS} ${INCLUDES} $*.c
 
 ${FS_EXE}: ${OBJS}
-	${CC} ${CFLAGS} ${LDFLAGS} ${LDPATH} -o ${FS_EXE} ${OBJS}
+	${CC} -o ${FS_EXE} ${OBJS} ${CFLAGS} ${LDFLAGS} ${LDPATH}
 
 ${LIB_SO}: ${OBJS}
-	${LD} ${LDFLAGS} ${LDPATH} -o ${LIB_SO} ${OBJS}
+	${LD} -o ${LIB_SO} ${OBJS} ${LDFLAGS} ${LDPATH}
 
 clean:
 	rm -f ${LIB_SO} ${FS_EXE} *.o


### PR DESCRIPTION
If the libraries come first the build fails with undefined reference errors.
You can read about it at http://webpages.charter.net/ppluzhnikov/linker.html
