### PR TITLE
Fix for use with OpenJDK 7 builds

### DIFF
--- a/native/make.flags
+++ b/native/make.flags
@@ -1,7 +1,7 @@
 FUSE_HOME=/usr/local
 JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/1.6.0/Home
 
-INCLUDES=-I${JAVA_HOME}/include -I${FUSE_HOME}/include
+INCLUDES=-I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin -I${FUSE_HOME}/include
 LDPATH=-L/Library/Java/Extensions -L/System/Library/Java/Extensions -L${FUSE_HOME}/lib -framework CoreFoundation -framework IOKit -framework JavaVM
 
 LIB_SO=libjavafs.jnilib


### PR DESCRIPTION
Builds from http://code.google.com/p/openjdk-osx-build/ have jni_md.h inside include/darwin instead of just include. This additional include should fix that.

Is there a way to make a universal build, by the way? Even just a 32-bit build; I'm having trouble doing that.
